### PR TITLE
Update pod

### DIFF
--- a/examples/markdown_viewer
+++ b/examples/markdown_viewer
@@ -3,7 +3,7 @@ use Mojolicious::Lite;
 use Text::Markdown qw/markdown/;
 use Encode qw/encode_utf8 decode_utf8/;
 
-plugin 'Directory', {
+plugin 'DirectoryServer', {
     auto_index => 0, # disabled directory index
     dir_index  => 'index.md',
     root       => app->home->rel_dir('documents'),

--- a/examples/markdown_viewer
+++ b/examples/markdown_viewer
@@ -6,11 +6,11 @@ use Encode qw/encode_utf8 decode_utf8/;
 plugin 'DirectoryServer', {
     auto_index => 0, # disabled directory index
     dir_index  => 'index.md',
-    root       => app->home->rel_dir('documents'),
+    root       => app->home->rel_file('documents'),
     handler    => sub {
         my ( $c, $path ) = @_;
         return unless $path =~ /\.(md|mkdn)$/;
-        my $markdown = Mojo::Util::slurp($path);
+        my $markdown = Mojo::File::slurp($path);
         my $html = markdown( decode_utf8 $markdown );
         $c->render( template => 'markdown', html => $html );
     },

--- a/lib/Mojolicious/Plugin/DirectoryServer.pm
+++ b/lib/Mojolicious/Plugin/DirectoryServer.pm
@@ -180,13 +180,13 @@ Mojolicious::Plugin::DirectoryServer - Serve static files from document root wit
 
   # simple usage
   use Mojolicious::Lite;
-  plugin( 'Directory', root => "/path/to/htdocs" )->start;
+  plugin( 'DirectoryServer', root => "/path/to/htdocs" )->start;
 
   # with handler
   use Text::Markdown qw{ markdown };
   use Path::Class;
   use Encode qw{ decode_utf8 };
-  plugin('Directory', root => "/path/to/htdocs", handler => sub {
+  plugin('DirectoryServer', root => "/path/to/htdocs", handler => sub {
       my ($c, $path) = @_;
       if ( -f $path && $path =~ /\.(md|mkdn)$/ ) {
           my $text = file($path)->slurp;
@@ -197,7 +197,7 @@ Mojolicious::Plugin::DirectoryServer - Serve static files from document root wit
 
 or
 
-  > perl -Mojo -E 'a->plugin("Directory", root => "/path/to/htdocs")->start' daemon
+  > perl -Mojo -E 'a->plugin("DirectoryServer", root => "/path/to/htdocs")->start' daemon
 
 or
 
@@ -205,23 +205,23 @@ or
 
 =head1 DESCRIPTION
 
-L<Mojolicious::Plugin::Directory> is a static file server with a
+L<Mojolicious::Plugin::DirectoryServer> is a static file server with a
 directory index similar to Apache's mod_autoindex.
 
 =head2 Methods
 
-L<Mojolicious::Plugin::Directory> inherits all methods from L<Mojolicious::Plugin>.
+L<Mojolicious::Plugin::DirectoryServer> inherits all methods from L<Mojolicious::Plugin>.
 
 =head2 Options
 
-L<Mojolicious::Plugin::Directory> supports the following options.
+L<Mojolicious::Plugin::DirectoryServer> supports the following options.
 
 =over 4
 
 =item * C<root>
 
   # Mojolicious::Lite
-  plugin Directory => { root => "/path/to/htdocs" };
+  plugin DirectoryServer => { root => "/path/to/htdocs" };
 
 Document root directory. Defaults to the current directory.
 
@@ -230,21 +230,21 @@ If root is a file, serve only root file.
 =item * C<auto_index>
 
    # Mojolicious::Lite
-   plugin Directory => { auto_index => 0 };
+   plugin DirectoryServer => { auto_index => 0 };
 
 Automatically generate index page for directory, default true.
 
 =item * C<dir_index>
 
   # Mojolicious::Lite
-  plugin Directory => { dir_index => [qw/index.html index.htm/] };
+  plugin DirectoryServer => { dir_index => [qw/index.html index.htm/] };
 
 Like a Apache's DirectoryIndex directive.
 
 =item * C<dir_page>
 
   # Mojolicious::Lite
-  plugin Directory => { dir_page => $template_str };
+  plugin DirectoryServer => { dir_page => $template_str };
 
 a HTML template of index page
 
@@ -254,7 +254,7 @@ a HTML template of index page
   use Text::Markdown qw{ markdown };
   use Path::Class;
   use Encode qw{ decode_utf8 };
-  plugin Directory => {
+  plugin DirectoryServer => {
       handler => sub {
           my ($c, $path) = @_;
           if ($path =~ /\.(md|mkdn)$/) {
@@ -274,7 +274,7 @@ If not rendered in CODEREF, serve as static file.
   # Mojolicious::Lite
   # /dir (Accept: application/json)
   # /dir?_format=json
-  plugin Directory => { json => 1 };
+  plugin DirectoryServer => { json => 1 };
 
 Enable json response.
 


### PR DESCRIPTION
Updated the old references from Directory to DirectoryServer in POD of main module as well as in example/markdownviewer.

markdownviewer used 2 deprecated Mojo methods.  Updated both to current.

No attribution expected or needed.

Just trying to pay back for many of your efforts from which I have benefited.